### PR TITLE
Revert chassis _get_heading documentation

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -98,10 +98,7 @@ class Chassis:
         self.vz = vz
 
     def _get_heading(self) -> Rotation2d:
-        """Get the current heading of the robot from the IMU. Note that this
-        uses our wrapper around the broken navx API, so it returns radians in
-        the robot coordinate system.
-        """
+        """Get the current heading of the robot from the IMU, anticlockwise positive."""
         return Rotation2d(self.imu.getYaw())
 
     def get_pose(self) -> Pose2d:


### PR DESCRIPTION
As a user of this, I don't care about how this gets the heading of the
robot, and a Rotation2d does not have units.