### PR TITLE
Remove navx reset method

### DIFF
--- a/utilities/nav_x.py
+++ b/utilities/nav_x.py
@@ -30,10 +30,6 @@ class NavX:
         raw = self.ahrs.getRoll()
         return -math.radians(raw)
 
-    def resetHeading(self):
-        """Zero the yaw."""
-        self.ahrs.reset()
-
     def getHeadingRate(self):
         """Get the rate of change of yaw in radians per second."""
         # multiply by update freq because NavX does not normalise per timestep


### PR DESCRIPTION
We will never want to reset the IMU heading, the offset is tracked in
the chassis component internally.  Don't allow anyone to break odometry.