### PR TITLE
Reduce turret MM status period back to default

### DIFF
--- a/components/turret.py
+++ b/components/turret.py
@@ -105,9 +105,6 @@ class Turret:
         self.motor.setStatusFramePeriod(
             ctre.StatusFrameEnhanced.Status_13_Base_PIDF0, 10, 10
         )
-        self.motor.setStatusFramePeriod(
-            ctre.StatusFrameEnhanced.Status_10_MotionMagic, 10, 10
-        )
         self.motor.config_kF(0, self.pidF, 10)
         self.motor.config_kP(0, self.pidP, 10)
         self.motor.config_IntegralZone(0, self.pidIZone, 10)


### PR DESCRIPTION
We aren't currently using any of this information AFAICT.

Leaving status frame 13 as is because there is currently a call to
getClosedLoopError().

https://phoenix-documentation.readthedocs.io/en/latest/ch18_CommonAPI.html