### PR TITLE
Name intake and injector motors in robot.py

### DIFF
--- a/components/indexer.py
+++ b/components/indexer.py
@@ -37,6 +37,7 @@ class Indexer:
         self.intake_right_motor.setInverted(False)
 
         self.injector_motor.setInverted(False)
+        self.indexer_motors[1].setInverted(False)
 
         self.indexer_speed = 0.6
         self.injector_speed = 0.7

--- a/components/shooter.py
+++ b/components/shooter.py
@@ -1,5 +1,4 @@
 import wpilib
-from typing import Sequence
 from wpilib import controller
 import ctre
 from numpy import interp
@@ -9,7 +8,7 @@ from magicbot import feedback, tunable
 class Shooter:
     outer_motor: ctre.WPI_TalonFX
     centre_motor: ctre.WPI_TalonFX
-    indexer_motors: Sequence[ctre.WPI_TalonSRX]
+    injector_motor: ctre.TalonSRX
     loading_piston: wpilib.DoubleSolenoid
     piston_switch: wpilib.DigitalInput
 
@@ -148,7 +147,7 @@ class Shooter:
         self.inject = True
 
     def is_ball_cleared(self) -> bool:
-        return not self.indexer_motors[-1].isFwdLimitSwitchClosed()
+        return not self.injector_motor.isFwdLimitSwitchClosed()
 
     def stop_motors(self) -> None:
         self.centre_target = 0

--- a/robot.py
+++ b/robot.py
@@ -64,13 +64,13 @@ class MyRobot(magicbot.MagicRobot):
         self.hang_winch_motor = ctre.WPI_TalonFX(30)
         self.hang_kracken_hook_latch = wpilib.DoubleSolenoid(4, 5)
 
+        self.intake_main_motor = ctre.WPI_TalonSRX(18)
         self.indexer_motors = [
-            ctre.WPI_TalonSRX(18),
             ctre.WPI_TalonSRX(11),
             ctre.WPI_TalonSRX(12),
             ctre.WPI_TalonSRX(13),
-            ctre.WPI_TalonSRX(14),
         ]
+        self.injector_motor = ctre.WPI_TalonSRX(14)
         self.piston_switch = wpilib.DigitalInput(4)  # checks if injector retracted
         self.intake_arm_piston = wpilib.Solenoid(1)
         self.intake_left_motor = rev.CANSparkMax(8, rev.MotorType.kBrushless)


### PR DESCRIPTION
This removes the magic numbers in the Indexer, making the special-case
logic for the intake and injector motors clearer.

This also means the Shooter only needs to know about the injector motor.