### PR TITLE
Call vision execute in disabled mode

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -100,6 +100,9 @@ class MyRobot(magicbot.MagicRobot):
         self.chassis.enable_closed_loop()
         self.indexer.shimmying = False
 
+    def disabledPeriodic(self) -> None:
+        self.vision.execute()
+
     def teleopInit(self) -> None:
         """Initialise things for driver control."""
         self.chassis.disable_closed_loop()


### PR DESCRIPTION
There is a [long standing bug in ntcore][1] which causes NetworkTables to
stop sending data to clients if you stop calling NetworkTables.flush().
Run our vision lag calculations in disabled mode to work around this.

[1]: https://github.com/wpilibsuite/ntcore/issues/275