### PR TITLE
Replace 3-second delay with adjust semantics for scan command

### DIFF
--- a/components/turret.py
+++ b/components/turret.py
@@ -186,19 +186,23 @@ class Turret:
 
     def scan(self, azimuth=math.pi) -> None:
         """
-        Slew the turret back and forth looking for a target
+        Slew the turret back and forth up to 90 degrees on either side, centred
+        at the given azimuth.
+
+        If the turret is already scanning, this adjusts the centre of the scan
+        rather than starting over.
         """
-        # The target must be downfield from us, so scan up to
-        # 90 degrees either side of the given heading
 
         if self.must_finish:
             return
-        # First reset scan size
-        self.current_scan_delta = self.SCAN_INCREMENT
+        # If we aren't already scanning, reset scan size
+        if self.current_state != self.SCANNING:
+            self.current_scan_delta = self.SCAN_INCREMENT
         turret_azimuth = _robot_to_turret(azimuth)
-        # set the first pass
+        # If we are starting a new scan, the following is the first pass.
+        # If we are adjusting an existing scan, this is the next adjusted pass.
         self._slew_to_counts(
-            turret_azimuth * self.COUNTS_PER_TURRET_RADIAN + self.SCAN_INCREMENT
+            turret_azimuth * self.COUNTS_PER_TURRET_RADIAN + self.current_scan_delta
         )
         self.current_state = self.SCANNING
 

--- a/controllers/shooter.py
+++ b/controllers/shooter.py
@@ -45,7 +45,6 @@ class ShooterController(StateMachine):
     )
     # in field co ordinates
 
-    MIN_SCAN_PERIOD = 3.0
     TARGET_LOST_TO_SCAN = 0.5
 
     def __init__(self) -> None:
@@ -102,23 +101,15 @@ class ShooterController(StateMachine):
             self.time_target_lost = None
             self.next_state("tracking")
         else:
-            # Scan starting straight downrange. TODO: remove this if the above
-            # seems worthwhile
+            # Scan starting straight downrange.
             time_now = time.monotonic()
             # Start a scan only if it's been a minimum time since we lost the target
             if (
                 self.time_target_lost is None
                 or (time_now - self.time_target_lost) > self.TARGET_LOST_TO_SCAN
             ):
-                # Start a scan only if it's been a minimum time since we started
-                # a scan. This allows the given scan to grow enough to find the
-                # target so that we don't just start the scan over every cycle.
-                if (
-                    self.time_of_last_scan is None
-                    or (time_now - self.time_of_last_scan) > self.MIN_SCAN_PERIOD
-                ):
-                    self.turret.scan(-self.chassis.get_heading())
-                    self.time_of_last_scan = time_now
+                self.turret.scan(-self.chassis.get_heading())
+                self.time_of_last_scan = time_now
 
     @state
     def tracking(self) -> None:


### PR DESCRIPTION
The scan command adjusts the centre of an ongoing scan, without resetting the scan increment to be small.

Draft until it's tested on the robot.